### PR TITLE
Feat/nickname update

### DIFF
--- a/Pawcus/Pawcus.xcodeproj/project.pbxproj
+++ b/Pawcus/Pawcus.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		BD1B70092DE57F7000E481E2 /* APIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1B70082DE57F7000E481E2 /* APIEndpoint.swift */; };
 		BD1B700C2DE5830B00E481E2 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1B700B2DE5830B00E481E2 /* AppConfig.swift */; };
 		BD4D143C2DF2C81200533171 /* StatisticView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4D143B2DF2C81200533171 /* StatisticView.swift */; };
+		BD56F7C82DF7FCFB00475A27 /* UserNamePromptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD56F7C72DF7FCFB00475A27 /* UserNamePromptViewModel.swift */; };
 		BD9893722DD9C47A00F40A9B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD98936D2DD9C47A00F40A9B /* Assets.xcassets */; };
 		BD9893732DD9C47A00F40A9B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD98936E2DD9C47A00F40A9B /* ContentView.swift */; };
 		BD9893742DD9C47A00F40A9B /* PawcusApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9893702DD9C47A00F40A9B /* PawcusApp.swift */; };
@@ -64,6 +65,7 @@
 		BD1B70082DE57F7000E481E2 /* APIEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpoint.swift; sourceTree = "<group>"; };
 		BD1B700B2DE5830B00E481E2 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		BD4D143B2DF2C81200533171 /* StatisticView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticView.swift; sourceTree = "<group>"; };
+		BD56F7C72DF7FCFB00475A27 /* UserNamePromptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNamePromptViewModel.swift; sourceTree = "<group>"; };
 		BD98933F2DD9C46800F40A9B /* Pawcus.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Pawcus.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD9893502DD9C46A00F40A9B /* PawcusTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PawcusTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD98935A2DD9C46A00F40A9B /* PawcusUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PawcusUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -175,6 +177,7 @@
 				BD0474EE2DEB4C5800960470 /* LoginView.swift */,
 				BD0474F02DEB4CFA00960470 /* LoginViewModel.swift */,
 				BD0474F22DEB58CA00960470 /* UserNamePromptView.swift */,
+				BD56F7C72DF7FCFB00475A27 /* UserNamePromptViewModel.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -502,6 +505,7 @@
 				BD1B700C2DE5830B00E481E2 /* AppConfig.swift in Sources */,
 				BD1B70092DE57F7000E481E2 /* APIEndpoint.swift in Sources */,
 				BD1B6FB32DDED98D00E481E2 /* RootView.swift in Sources */,
+				BD56F7C82DF7FCFB00475A27 /* UserNamePromptViewModel.swift in Sources */,
 				BD0474E62DEAB03900960470 /* ProfileView.swift in Sources */,
 				BD9893A52DD9DD2400F40A9B /* LeaderBoardView.swift in Sources */,
 				BD9893742DD9C47A00F40A9B /* PawcusApp.swift in Sources */,

--- a/Pawcus/Pawcus/Data/Models/UserRegisterDTO.swift
+++ b/Pawcus/Pawcus/Data/Models/UserRegisterDTO.swift
@@ -13,6 +13,11 @@ struct UserData: Codable {
     let createdAt: String
 }
 
+struct SimpleUserData: Codable {
+    let userId: String
+    let nickname: String
+}
+
 struct TokenData: Codable {
     let accessToken: String
     let refreshToken: String

--- a/Pawcus/Pawcus/Data/Network/APIEndpoint.swift
+++ b/Pawcus/Pawcus/Data/Network/APIEndpoint.swift
@@ -25,7 +25,7 @@ enum APIEndpoint {
     var path: String {
         switch self {
         case .checkNickname:
-            return "/guest-users/is-nickname-duplicated"
+            return "/user/nickname/check"
         case .registerGuest:
             return "/guest-users"
         case .registerSocialUser:

--- a/Pawcus/Pawcus/Data/Network/APIEndpoint.swift
+++ b/Pawcus/Pawcus/Data/Network/APIEndpoint.swift
@@ -41,7 +41,7 @@ enum APIEndpoint {
         case .getUserLogs:
             return "usage-log"
         case .getGuestToken:
-            return "/guest-users/get-token"
+            return "/user/get-token"
         case .tokenRefresh:
             return "/auth/refresh"
         case .updateNickname:

--- a/Pawcus/Pawcus/Data/Network/APIEndpoint.swift
+++ b/Pawcus/Pawcus/Data/Network/APIEndpoint.swift
@@ -12,7 +12,7 @@ enum APIEndpoint {
     
     case checkNickname(nickname: String)
     case registerGuest
-    case registerSocialUser
+    case loginSocialUser
     case uploadLog
     case getCategories
     case getUserRanksByCategory(category: String, page: Int?, size: Int?, date: String)
@@ -27,8 +27,8 @@ enum APIEndpoint {
         case .checkNickname:
             return "/user/nickname/check"
         case .registerGuest:
-            return "/guest-users"
-        case .registerSocialUser:
+            return "/user"
+        case .loginSocialUser:
             return "/auth/social-login"
         case .uploadLog:
             return "/usage-log"
@@ -53,7 +53,7 @@ enum APIEndpoint {
         switch self {
         case .checkNickname: return "GET"
         case .registerGuest: return "POST"
-        case .registerSocialUser: return "POST"
+        case .loginSocialUser: return "POST"
         case .uploadLog: return "POST"
         case .getCategories: return "GET"
         case .getUserRanksByCategory: return "GET"

--- a/Pawcus/Pawcus/Data/Network/APIEndpoint.swift
+++ b/Pawcus/Pawcus/Data/Network/APIEndpoint.swift
@@ -20,6 +20,7 @@ enum APIEndpoint {
     case getUserLogs(userId: String, date: String)
     case getGuestToken
     case tokenRefresh
+    case updateNickname
     
     var path: String {
         switch self {
@@ -43,6 +44,8 @@ enum APIEndpoint {
             return "/guest-users/get-token"
         case .tokenRefresh:
             return "/auth/refresh"
+        case .updateNickname:
+            return "guest-users/nickname"
         }
     }
 
@@ -58,6 +61,7 @@ enum APIEndpoint {
         case .getUserLogs: return "GET"
         case .getGuestToken: return "POST"
         case .tokenRefresh: return "POST"
+        case .updateNickname: return "PATCH"
         }
     }
 

--- a/Pawcus/Pawcus/Data/Network/APIEndpoint.swift
+++ b/Pawcus/Pawcus/Data/Network/APIEndpoint.swift
@@ -45,7 +45,7 @@ enum APIEndpoint {
         case .tokenRefresh:
             return "/auth/refresh"
         case .updateNickname:
-            return "guest-users/nickname"
+            return "user/nickname"
         }
     }
 

--- a/Pawcus/Pawcus/Data/RepositoriesImpl/AnalysisRepositoryImpl.swift
+++ b/Pawcus/Pawcus/Data/RepositoriesImpl/AnalysisRepositoryImpl.swift
@@ -19,7 +19,7 @@ final class AnalysisRepositoryImpl: AnalysisRepository {
     }
     
     func getUsageCategoryStat(userId: String? = nil , date: Date) async throws -> [UsageCategoryStat] {
-        let userId = UserDefaults.standard.string(forKey: "userId") ?? UUID().uuidString
+        let userId = UserDefaults.standard.string(forKey: .userId) ?? UUID().uuidString
         return try await service.fetchUsageCategoryStat(userId: userId, date: date.formattedDateString).map{$0.toDomain()}
     }
 }

--- a/Pawcus/Pawcus/Data/RepositoriesImpl/RegisterUserRepositoryImpl.swift
+++ b/Pawcus/Pawcus/Data/RepositoriesImpl/RegisterUserRepositoryImpl.swift
@@ -11,7 +11,7 @@ import SwiftUI
 final class RegisterUserRepositoryImpl: RegisterUserRepository {
     
     private let service: UserRegisterService
-    @AppStorage("isLoggedIn") private var isLoggedIn: Bool = false
+    
     init(service: UserRegisterService) {
         self.service = service
     }
@@ -23,24 +23,24 @@ final class RegisterUserRepositoryImpl: RegisterUserRepository {
     
     func updateNickname(_ nickname: String) async throws {
         if try await service.updateNickname(nickname) {
-            UserDefaults.standard.set(nickname, forKey: "userNickname")
+            UserDefaults.standard.set(nickname, forKey: .userNickname)
         }
     }
     
     func registerGuest() async throws -> Bool {
         let uuid = UUID().uuidString
         let userData = try await service.registerGuest(uuid: uuid)
-        UserDefaults.standard.set(userData.nickname, forKey: "userNickname")
-        UserDefaults.standard.set(uuid, forKey: "userId")
-        UserDefaults.standard.set(userData.createdAt, forKey: "createdAt")
-        isLoggedIn = true
+        UserDefaults.standard.set(userData.nickname, forKey: .userNickname)
+        UserDefaults.standard.set(uuid, forKey: .userId)
+        UserDefaults.standard.set(userData.createdAt, forKey: .createdAt)
+        UserDefaults.standard.set(true, forKey: .isLoggedIn)
         return true
     }
     
     func registerSocialUser(accessToken: String) async throws {
         let tokenData = try await service.registerSocialUser(accessToken: accessToken)
         // 네트워크 호출 결과로 받은 토큰을 로컬에 저장
-        isLoggedIn = true
+        UserDefaults.standard.set(true, forKey: .isLoggedIn)
         KeychainHelper.standard.save(tokenData.accessToken,
                                      service: "com.pawcus.token",
                                      account: "accessToken")
@@ -51,7 +51,7 @@ final class RegisterUserRepositoryImpl: RegisterUserRepository {
     
     func getGuestToken() async throws {
         let tokenData = try await service.getGuestToken()
-        isLoggedIn = true
+        UserDefaults.standard.set(true, forKey: .isLoggedIn)
         KeychainHelper.standard.save(tokenData.accessToken, service: "com.pawcus.token", account: "accessToken")
         KeychainHelper.standard.save(tokenData.refreshToken, service: "com.pawcus.token", account: "refreshToken")
     }

--- a/Pawcus/Pawcus/Data/RepositoriesImpl/RegisterUserRepositoryImpl.swift
+++ b/Pawcus/Pawcus/Data/RepositoriesImpl/RegisterUserRepositoryImpl.swift
@@ -21,6 +21,12 @@ final class RegisterUserRepositoryImpl: RegisterUserRepository {
         return isValid
     }
     
+    func updateNickname(_ nickname: String) async throws {
+        if try await service.updateNickname(nickname) {
+            UserDefaults.standard.set(nickname, forKey: "userNickname")
+        }
+    }
+    
     func registerGuest() async throws -> Bool {
         let uuid = UUID().uuidString
         let userData = try await service.registerGuest(uuid: uuid)

--- a/Pawcus/Pawcus/Data/RepositoriesImpl/RegisterUserRepositoryImpl.swift
+++ b/Pawcus/Pawcus/Data/RepositoriesImpl/RegisterUserRepositoryImpl.swift
@@ -21,10 +21,10 @@ final class RegisterUserRepositoryImpl: RegisterUserRepository {
         return isValid
     }
     
-    func registerGuest(nickname: String) async throws -> Bool {
+    func registerGuest() async throws -> Bool {
         let uuid = UUID().uuidString
-        let userData = try await service.registerGuest(uuid: uuid, nickname: nickname)
-        UserDefaults.standard.set(nickname, forKey: "userNickname")
+        let userData = try await service.registerGuest(uuid: uuid)
+        UserDefaults.standard.set(userData.nickname, forKey: "userNickname")
         UserDefaults.standard.set(uuid, forKey: "userId")
         UserDefaults.standard.set(userData.createdAt, forKey: "createdAt")
         isLoggedIn = true

--- a/Pawcus/Pawcus/Data/Services/SupabaseAuthService.swift
+++ b/Pawcus/Pawcus/Data/Services/SupabaseAuthService.swift
@@ -10,7 +10,6 @@ import Supabase
 import SwiftUI
 
 final class SupabaseAuthService {
-    @AppStorage("isLoggedIn") private var isLoggedIn: Bool = false
     
     func loginWithGoogle() async -> Bool  {
         do {
@@ -43,7 +42,7 @@ final class SupabaseAuthService {
     func logout() async {
         do {
             try await supabase.auth.signOut()
-            isLoggedIn = false
+            UserDefaults.standard.set(false, forKey: .isLoggedIn)
             print("Logout successful")
         } catch {
             print("Logout failed: \(error)")

--- a/Pawcus/Pawcus/Data/Services/TokenService.swift
+++ b/Pawcus/Pawcus/Data/Services/TokenService.swift
@@ -39,8 +39,8 @@ enum TokenManager {
             saveTokens(newTokens)
         } else {
             // ⛔ RTK까지 만료 → userId + createdAt로 재발급
-            guard let userId = UserDefaults.standard.string(forKey: "userId"),
-                  let createdAt = UserDefaults.standard.string(forKey: "createdAt") else {
+            guard let userId = UserDefaults.standard.string(forKey: .userId),
+                  let createdAt = UserDefaults.standard.string(forKey: .createdAt) else {
                 throw AuthError.noUserData
             }
 

--- a/Pawcus/Pawcus/Data/Services/UserRegisterService.swift
+++ b/Pawcus/Pawcus/Data/Services/UserRegisterService.swift
@@ -41,8 +41,10 @@ final class UserRegisterService {
         request.httpBody = try JSONEncoder().encode(body)
         let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            print(response as? HTTPURLResponse)
             throw URLError(.badServerResponse)
         }
+        print(http)
         let result = try JSONDecoder().decode(ServerResponse<UserData>.self, from: data)
         guard result.isSuccess, let userData = result.data else {
             throw NSError(domain: "UserRegisterService", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: result.message ?? "Unknown error"])

--- a/Pawcus/Pawcus/Data/Services/UserRegisterService.swift
+++ b/Pawcus/Pawcus/Data/Services/UserRegisterService.swift
@@ -72,8 +72,8 @@ final class UserRegisterService {
     }
     
     func getGuestToken() async throws -> TokenData {
-        guard let userId = UserDefaults.standard.string(forKey: "userId"),
-              let createdAt = UserDefaults.standard.string(forKey: "createdAt") else {
+        guard let userId = UserDefaults.standard.string(forKey: .userId),
+              let createdAt = UserDefaults.standard.string(forKey: .createdAt) else {
             throw NSError(domain: "UserRegisterService", code: 0, userInfo: [NSLocalizedDescriptionKey: "Missing userID or createdAt in UserDefaults"])
         }
 

--- a/Pawcus/Pawcus/Data/Services/UserRegisterService.swift
+++ b/Pawcus/Pawcus/Data/Services/UserRegisterService.swift
@@ -31,13 +31,13 @@ final class UserRegisterService {
         return result.data ?? true
     }
     
-    func registerGuest(uuid: String, nickname: String) async throws -> UserData {
+    func registerGuest(uuid: String) async throws -> UserData {
         let endpoint = APIEndpoint.registerGuest
         let url = endpoint.url()
         var request = URLRequest(url: url)
         request.httpMethod = endpoint.method
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        let body = ["userId": uuid, "nickname": nickname]
+        let body = ["userId": uuid]
         request.httpBody = try JSONEncoder().encode(body)
         let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
@@ -52,7 +52,7 @@ final class UserRegisterService {
     
     /// 소셜 로그인 회원 등록
     func registerSocialUser(accessToken: String) async throws -> TokenData {
-        let endpoint = APIEndpoint.registerSocialUser
+        let endpoint = APIEndpoint.loginSocialUser
         let url = endpoint.url()
         var request = URLRequest(url: url)
         request.httpMethod = endpoint.method

--- a/Pawcus/Pawcus/Data/Services/UserRegisterService.swift
+++ b/Pawcus/Pawcus/Data/Services/UserRegisterService.swift
@@ -41,7 +41,6 @@ final class UserRegisterService {
         request.httpBody = try JSONEncoder().encode(body)
         let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
-            print(response as? HTTPURLResponse)
             throw URLError(.badServerResponse)
         }
         print(http)
@@ -101,7 +100,7 @@ final class UserRegisterService {
     }
     
     /// 닉네임 업데이트
-    func updateNickname(_ newNickname: String) async throws {
+    func updateNickname(_ newNickname: String) async throws -> Bool {
         let endpoint = APIEndpoint.updateNickname
         let url = endpoint.url()
         var request = URLRequest(url: url)
@@ -120,5 +119,6 @@ final class UserRegisterService {
         guard result.isSuccess, let _ = result.data else {
             throw NSError(domain: "UserRegisterService", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: result.message ?? "Unknown error"])
         }
+        return true 
     }
 }

--- a/Pawcus/Pawcus/Data/Services/UserRegisterService.swift
+++ b/Pawcus/Pawcus/Data/Services/UserRegisterService.swift
@@ -97,4 +97,26 @@ final class UserRegisterService {
 
         return tokenData
     }
+    
+    /// 닉네임 업데이트
+    func updateNickname(_ newNickname: String) async throws {
+        let endpoint = APIEndpoint.updateNickname
+        let url = endpoint.url()
+        var request = URLRequest(url: url)
+        request.httpMethod = endpoint.method
+        request.addJSONHeader()
+        request.addBearerToken()
+        let body = ["nickname": newNickname]
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+
+        let result = try JSONDecoder().decode(ServerResponse<SimpleUserData>.self, from: data)
+        guard result.isSuccess, let _ = result.data else {
+            throw NSError(domain: "UserRegisterService", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: result.message ?? "Unknown error"])
+        }
+    }
 }

--- a/Pawcus/Pawcus/Domain/Repositories /RegisterUserRepository.swift
+++ b/Pawcus/Pawcus/Domain/Repositories /RegisterUserRepository.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol RegisterUserRepository {
     func checkNicknameAvailability(nickname: String) async throws -> Bool
-    func registerGuest(nickname: String) async throws -> Bool
+    func registerGuest() async throws -> Bool
     func registerSocialUser(accessToken: String) async throws
     func getGuestToken() async throws
 }

--- a/Pawcus/Pawcus/Domain/Repositories /RegisterUserRepository.swift
+++ b/Pawcus/Pawcus/Domain/Repositories /RegisterUserRepository.swift
@@ -9,6 +9,7 @@ import Foundation
 
 protocol RegisterUserRepository {
     func checkNicknameAvailability(nickname: String) async throws -> Bool
+    func updateNickname(_ nickname: String) async throws
     func registerGuest() async throws -> Bool
     func registerSocialUser(accessToken: String) async throws
     func getGuestToken() async throws

--- a/Pawcus/Pawcus/Domain/UseCases/RegisterUserUseCase.swift
+++ b/Pawcus/Pawcus/Domain/UseCases/RegisterUserUseCase.swift
@@ -25,4 +25,8 @@ final class RegisterUserUseCase {
     func registerSocialUser(accessToken: String) async throws {
         try await repository.registerSocialUser(accessToken: accessToken)
     }
+    
+    func updateNickname(_ nickname: String) async throws {
+        try await repository.updateNickname(nickname)
+    }
 }

--- a/Pawcus/Pawcus/Domain/UseCases/RegisterUserUseCase.swift
+++ b/Pawcus/Pawcus/Domain/UseCases/RegisterUserUseCase.swift
@@ -16,8 +16,8 @@ final class RegisterUserUseCase {
         return try await repository.checkNicknameAvailability(nickname: nickname)
     }
     
-    func registerGuest(nickname: String) async throws {
-        if try await repository.registerGuest(nickname: nickname) {
+    func registerGuest() async throws {
+        if try await repository.registerGuest() {
             try await repository.getGuestToken()
         }
     }

--- a/Pawcus/Pawcus/Infrastructure/Utilities/UserDefaults+Extension.swift
+++ b/Pawcus/Pawcus/Infrastructure/Utilities/UserDefaults+Extension.swift
@@ -1,0 +1,51 @@
+//
+//  UserDefaults+Extension.swift
+//  Pawcus
+//
+//  Created by 김정원 on 6/10/25.
+//
+
+import Foundation
+
+/// UserDefaults에 저장할 키를 모아두는 enum
+enum UserDefaultKey: String {
+    case userNickname
+    case userId
+    case isLoggedIn
+    case dailyWorkSeconds
+    case lastRecordedDate
+    case createdAt
+}
+
+extension UserDefaults {
+    
+    /// 값 저장하기
+    func set<T>(_ value: T, forKey key: UserDefaultKey) {
+        set(value, forKey: key.rawValue)
+    }
+    
+    /// 값 읽어오기 (타입 안전)
+    func value<T>(forKey key: UserDefaultKey) -> T? {
+        return object(forKey: key.rawValue) as? T
+    }
+    
+    /// Bool 읽기 전용 편의 메서드
+    func bool(forKey key: UserDefaultKey) -> Bool {
+        return bool(forKey: key.rawValue)
+    }
+    
+    /// Int 읽기 전용 편의 메서드
+    func integer(forKey key: UserDefaultKey) -> Int {
+        return integer(forKey: key.rawValue)
+    }
+    
+    /// 문자열 읽기 전용 편의 메서드
+    func string(forKey key: UserDefaultKey) -> String? {
+        return string(forKey: key.rawValue)
+    }
+    
+    /// 값 삭제하기
+    func remove(_ key: UserDefaultKey) {
+        removeObject(forKey: key.rawValue)
+    }
+}

--- a/Pawcus/Pawcus/Presentation/Login/LoginViewModel.swift
+++ b/Pawcus/Pawcus/Presentation/Login/LoginViewModel.swift
@@ -45,7 +45,7 @@ final class LoginViewModel: ObservableObject {
     
     func continueAsGuest() async {
         do {
-            try await registerUserUseCase.registerGuest(nickname: "")
+            try await registerUserUseCase.registerGuest()
         } catch {
             
         }

--- a/Pawcus/Pawcus/Presentation/Login/UserNamePromptView.swift
+++ b/Pawcus/Pawcus/Presentation/Login/UserNamePromptView.swift
@@ -82,7 +82,7 @@ struct UserNamePromptView: View {
 //                                try await useCase.registerGuest(nickname: trimmedNickname)
                                 username = trimmedNickname
                                 dismiss() 
-                                UserDefaults.standard.set(0, forKey: "dailyWorkSeconds")
+                                UserDefaults.standard.set(0, forKey: .dailyWorkSeconds)
                             } catch {
                                 statusMessage = error.localizedDescription
                             }

--- a/Pawcus/Pawcus/Presentation/Login/UserNamePromptViewModel.swift
+++ b/Pawcus/Pawcus/Presentation/Login/UserNamePromptViewModel.swift
@@ -1,0 +1,85 @@
+//
+//  UserNamePromptViewModel.swift
+//  Pawcus
+//
+//  Created by 김정원 on 6/10/25.
+//
+
+import Combine
+import Foundation
+import Factory
+import SwiftUI
+
+final class UserNamePromptViewModel: ObservableObject {
+    @Injected(\.registerUserUseCase) private var useCase: RegisterUserUseCase
+
+    @Published var tempInput: String = ""
+    @Published var isValidNickname: Bool? = nil
+    @Published var statusMessage: String? = nil
+    @Published var isChecking: Bool = false
+    @Published var didConfirm: Bool = false
+    
+    var nicknameStatusImage: String? {
+        if isChecking { return nil }
+        if let valid = isValidNickname {
+            return valid ? "checkmark.circle.fill" : "xmark.circle.fill"
+        } else if statusMessage != nil {
+            return "exclamationmark.triangle.fill"
+        }
+        return nil
+    }
+
+    var nicknameStatusColor: Color {
+        if isValidNickname == nil {
+            return .orange
+        } else {
+            return isValidNickname! ? .green : .red
+        }
+    }
+    
+    func showCancelButton() -> Bool {
+        return UserDefaults.standard.string(forKey: .userNickname) != nil
+    }
+
+    /// 입력한 닉네임으로 검사
+    func validate() async {
+        await MainActor.run {
+            isChecking = true
+            isValidNickname = nil
+            statusMessage = nil
+        }
+        do {
+            let valid = try await useCase.checkNicknameAvailability(
+                nickname: tempInput.trimmingCharacters(in: .whitespaces)
+            )
+            await MainActor.run {
+                isValidNickname = valid
+                statusMessage = valid
+                    ? "Nickname is available."
+                    : "Nickname is already taken"
+                isChecking = false
+            }
+        } catch {
+            await MainActor.run {
+                statusMessage = error.localizedDescription
+                isChecking = false
+            }
+        }
+    }
+
+    /// 닉네임 업데이트
+    func confirm() async {
+        let trimmed = tempInput.trimmingCharacters(in: .whitespaces)
+        do {
+            try await useCase.updateNickname(trimmed)
+            await MainActor.run {
+                didConfirm = true
+            }
+
+        } catch {
+            await MainActor.run {
+                statusMessage = error.localizedDescription
+            }
+        }
+    }
+}

--- a/Pawcus/Pawcus/Presentation/Profile/ProfileView.swift
+++ b/Pawcus/Pawcus/Presentation/Profile/ProfileView.swift
@@ -43,11 +43,11 @@ struct ProfileView: View {
                     try appLogLocalDataSource.removeAllAppLogs(context: context)
                 }
                 let defaults = UserDefaults.standard
-                defaults.removeObject(forKey: "userNickname")
-                defaults.removeObject(forKey: "userId")
-                defaults.removeObject(forKey: "isLoggedIn")
-                defaults.removeObject(forKey: "dailyWorkSeconds")
-                defaults.removeObject(forKey: "lastRecordedDate")
+                defaults.remove(.userNickname)
+                defaults.remove(.userId)
+                defaults.remove(.isLoggedIn)
+                defaults.remove(.dailyWorkSeconds)
+                defaults.remove(.lastRecordedDate)
                 KeychainHelper.standard.save("", service: "com.pawcus.token", account: "accessToken")
                 KeychainHelper.standard.save("", service: "com.pawcus.token", account: "refreshToken")
             }


### PR DESCRIPTION
## What is this PR? 🔍

- 닉네임 수정 UX 개선 (연필 아이콘 또는 간단한 팝업 인터랙션 고려)
- 등록된 유저가 userNickname을 보유하지 않은 경우, UserNamePromptView를 통해 닉네임 입력을 요구
- 닉네임 입력 뷰 뷰모델로 책임 분리
- 유저디포트 익스텐션으로 enum 화

---

## Changes ✏️

- registerSocialUser(accessToken:) 기능 구현
- RegisterUserUseCase 및 RegisterUserRepository에 updateNickname(_:) 추가
- UserRegisterService에서 닉네임 변경 PATCH API 연동
- UserNamePromptViewModel 생성 및 뷰 분리
- UserDefaults+Extension 추가 (UserDefaultKey enum 기반 키 관리)
- 닉네임 상태에 따른 statusImage 및 statusColor 로직 뷰모델로 이동
- ProfileView 로그아웃 시 UserDefaults 키 enum 기반으로 정리
- 기존 nickname validation 로직 리팩토링 및 ViewModel화

---

## **Screenshot 📸**

| Case         | Image |
|--------------|-------|
| ✅ 닉네임 사용 가능 | ![Available](https://github.com/user-attachments/assets/94de533f-7564-45e0-98d7-5c3bbfa3c474) |
| ❌ 닉네임 중복됨   | ![Duplicate](https://github.com/user-attachments/assets/0564cab3-90b6-4db3-bad0-78753f64cb9a) |
| ⚠️ 네트워크 오류 등 예외 | ![Error](https://github.com/user-attachments/assets/4c1bf08f-48ad-4660-9c59-98e21989319b) |

---

### **💡 고려한 점 / 고민**

- 소셜, 게스트 구분없이 초기 회원 등록은 닉네임이 없이 이루어지고 추후에 닉네임이 비었다면 닉네임을 입력하는 화면을 띄우기로 하여 분기처리를 했습니다.

---
