### PR TITLE
Fix/Sidebar UI 수정 

### DIFF
--- a/Pawcus/Pawcus/App/PawcusApp.swift
+++ b/Pawcus/Pawcus/App/PawcusApp.swift
@@ -21,8 +21,8 @@ struct PawcusApp: App {
         WindowGroup {
             RootView()
                 .environmentObject(dailyWorkTimeStore)
-//            StatisticView()
         }
+        .windowStyle(HiddenTitleBarWindowStyle())
         .modelContainer(for: [AppLogEntity.self])
     }
 }

--- a/Pawcus/Pawcus/Presentation/DailyWorkTimeStore.swift
+++ b/Pawcus/Pawcus/Presentation/DailyWorkTimeStore.swift
@@ -57,6 +57,7 @@ final class DailyWorkTimeStore: ObservableObject {
     // MARK: - 타이머 시작/중지
 
     func start() {
+        appUsageLogger.startLogging()
         isRunning = true
         refreshIfNewDay()
         if isRunning {
@@ -76,6 +77,7 @@ final class DailyWorkTimeStore: ObservableObject {
     }
 
     func stop() {
+        appUsageLogger.stopLogging()
         isRunning = false
         timer?.cancel()
         timer = nil

--- a/Pawcus/Pawcus/Presentation/Home/HomeView.swift
+++ b/Pawcus/Pawcus/Presentation/Home/HomeView.swift
@@ -15,7 +15,6 @@ struct HomeView: View {
     // MARK: - Properties
     @AppStorage("dailyWorkSeconds") private var storedSeconds: Int = 0
     @EnvironmentObject private var timeStore: DailyWorkTimeStore
-    @Injected(\.activityLogger) private var appUsageLogger: ActivityLogger
     
     // MARK: - Body
     var body: some View {
@@ -55,7 +54,9 @@ struct HomeView: View {
     }
 
     private var playPauseButton: some View {
-        Button(action: toggleTimer) {
+        Button(action: {
+            timeStore.isRunning ? timeStore.stop() : timeStore.start()
+        }) {
             Image(systemName: timeStore.isRunning ? "stop.fill" : "play.fill")
                 .font(.title3)
                 .padding()
@@ -69,26 +70,13 @@ struct HomeView: View {
     }
 
     private var resetButton: some View {
-        Button(action: resetTimer) {
+        Button(action: {
+            timeStore.reset()
+        }) {
             Image(systemName: "arrow.trianglehead.counterclockwise")
                 .font(.title2)
         }
         .buttonStyle(.plain)
-    }
-
-    // MARK: - Actions
-    private func toggleTimer() {
-        if timeStore.isRunning {
-            timeStore.stop()
-            appUsageLogger.stopLogging()
-        } else {
-            timeStore.start()
-            appUsageLogger.startLogging()
-        }
-    }
-
-    private func resetTimer() {
-        timeStore.reset()
     }
 }
 

--- a/Pawcus/Pawcus/Presentation/Root/ContentView.swift
+++ b/Pawcus/Pawcus/Presentation/Root/ContentView.swift
@@ -9,17 +9,18 @@ import SwiftUI
 
 struct ContentView: View {
     @AppStorage("userNickname") private var username: String = ""
+    @AppStorage(UserDefaultKey.dailyWorkSeconds.rawValue) private var storedTime: Int = 0
+
     @State private var showUsernamePrompt: Bool = false
+    @EnvironmentObject private var timeStore: DailyWorkTimeStore
     
     enum Tab: String, CaseIterable, Identifiable, Hashable {
-        case home = "Home"
         case leaderboard = "LeaderBoard"
         case analysis = "Analysis"
         case profile = "Profile"
         case web = "web"
         var imageName : String {
             switch self {
-            case .home:  return "house.fill"
             case .leaderboard: return "chart.bar.fill"
             case .analysis: return "magnifyingglass.circle.fill"
             case .profile: return "person.crop.circle.fill"
@@ -28,33 +29,69 @@ struct ContentView: View {
         }
         var id: String { rawValue }
     }
+    
     @StateObject var leaderViewModel: LeaderBoardViewModel = LeaderBoardViewModel()
     @StateObject var analysisViewModel: AnalysisViewModel = AnalysisViewModel()
     
-    @State private var selection: Tab? = .home
+    @State private var selection: Tab? = .leaderboard
     var body: some View {
-        NavigationSplitView {
-            List(Tab.allCases, selection: $selection) { tab in
-                Label(tab.rawValue, systemImage: tab.imageName)
-                    .tag(tab)
+        HStack(alignment: .center, spacing: 0){
+            VStack {
+                ForEach(Tab.allCases, id: \.self) { tab in
+                    Button(action: {
+                        selection = tab
+                    }) {
+                        Image(systemName:  tab.imageName)
+                            .foregroundStyle(selection == tab ? .accent : .secondary)
+                            .font(.title)
+                            .padding(.vertical)
+                            .frame(width: 70, height: 50)
+
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.top,5)
+                Divider()
+                    .padding()
+                Spacer()
+                Image(systemName: timeStore.isRunning ? "stop.fill" : "play.fill")
+                    .font(.largeTitle)
+                    .frame(width: 70, height: 50)
+                    .foregroundStyle(.white)
+                    .background(
+                        LinearGradient(
+                            colors: [timeStore.isRunning ? .red : .indigo, timeStore.isRunning ? .pink.opacity(0.5) : .blue.opacity(0.6)],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .onTapGesture {
+                        timeStore.isRunning ? timeStore.stop() : timeStore.start()
+                    }
+                    .padding()
             }
-            .listStyle(.sidebar)
-            .navigationTitle("Tabs")
-        } detail: {
-            switch selection {
-            case .home:
-                HomeView()
-            case .leaderboard:
-                LeaderBoardView(viewModel: leaderViewModel)
-            case .analysis:
-                AnalysisView(viewModel: analysisViewModel)
-            case .profile:
-                ProfileView()
-            case .web:
-                StatisticView()
-            case .none:
-                Text("Select a tab")
+            .frame(width: 100)
+            .background(Color(.windowBackgroundColor))
+            
+            Divider()
+                .ignoresSafeArea()
+            
+            Group {
+                switch selection {
+                case .leaderboard:
+                    LeaderBoardView(viewModel: leaderViewModel)
+                case .analysis:
+                    AnalysisView(viewModel: analysisViewModel)
+                case .web:
+                    StatisticView()
+                case .profile:
+                    ProfileView()
+                case .none:
+                    Text("Select a tab")
+                }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .onAppear {
             showUsernamePrompt = username.isEmpty


### PR DESCRIPTION
## What is this PR? 🔍

- 기본 ContentView 에서 Sidebar 관련 로직 수정 

---

## Changes ✏️

- 기존의 context 를 주입하는 걸 뷰에서 하지 않아도 되기 때문에 뷰의 로직을 간소화 했습니다.
- 로컬 타이머를 지우고, 기록을 시작하는 용도로 사이드바에 위치 시켰습니다.
- NavigationSplitView → 커스텀 탭바 전환

---

## **Screenshot 📸**

| Case         | Image |
|--------------|-------|
| ✅ 시작  | <img width="300" alt="스크린샷 2025-06-12 오전 10 18 27" src="https://github.com/user-attachments/assets/8633d876-f37d-4fad-8aac-e1f17b5cfcfb" /> |
| ❌ 중단   | <img width="300" alt="스크린샷 2025-06-12 오전 10 19 03" src="https://github.com/user-attachments/assets/483c5623-9fbb-4edd-810a-cd6512cba23f" /> |
---

### **💡 고려한 점 / 고민**

- 기존의 NavigationSplitView 는 웹뷰와의 디자인 호환에 있어서 커스텀 하기 어려운점이 있어 커스텀 탭바로 전환 했습니다.
- 로컬 타이머와 서버에서 분석해준 타이머가 맞지 않는 점을 고려해 로컬에서 시간 측정 로직을 지웠습니다.

---




