### PR TITLE
feat: WebDomain 추적

### DIFF
--- a/Pawcus/Pawcus-Info.plist
+++ b/Pawcus/Pawcus-Info.plist
@@ -28,5 +28,7 @@
 	<string>$(SUPABASE_KEY)</string>
 	<key>SUPublicEDKey</key>
 	<string>XYqUVZF83dzRohHy5RGDM0wYkGdJlKVqvsikWBAKAmk=</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Pawcus가 웹 브라우저(Safari, Chrome, Arc 등)에서 현재 보고 있는 URL을 추적하여 사용 통계를 제공하기 위해 Apple Events 권한이 필요합니다.</string>
 </dict>
 </plist>

--- a/Pawcus/Pawcus/Infrastructure/Services/ActivityLogger.swift
+++ b/Pawcus/Pawcus/Infrastructure/Services/ActivityLogger.swift
@@ -94,6 +94,90 @@ final class ActivityLogger {
                 titleString = axTitle
             }
         }
+        
+        // 웹 브라우저인 경우 URL 추출 시도
+        if isWebBrowser(appName) {
+            if let url = getBrowserURL(appName: appName, pid: pid) {
+                titleString = url
+            }
+        }
+        
         return UsageLog(timestamp: .now, duration: 0, title: titleString, app: appName)
+    }
+    
+    /// 웹 브라우저인지 확인하는 메서드
+    private func isWebBrowser(_ appName: String) -> Bool {
+        let browsers = ["Safari", "Google Chrome", "Arc", "Firefox", "Microsoft Edge", "Opera"]
+        return browsers.contains { browser in
+            appName.lowercased().contains(browser.lowercased())
+        }
+    }
+    
+    /// 브라우저에서 현재 URL을 가져오는 메서드
+    private func getBrowserURL(appName: String, pid: pid_t) -> String? {
+        let script: String
+        
+        switch appName.lowercased() {
+        case let name where name.contains("safari"):
+            script = "tell application \"Safari\" to return URL of current tab of front window"
+        case let name where name.contains("chrome"):
+            script = "tell application \"Google Chrome\" to return URL of active tab of front window"
+        case let name where name.contains("arc"):
+            script = "tell application \"Arc\" to return URL of active tab of front window"
+        case let name where name.contains("firefox"):
+            script = "tell application \"Firefox\" to return URL of active tab of front window"
+        case let name where name.contains("edge"):
+            script = "tell application \"Microsoft Edge\" to return URL of active tab of front window"
+        default:
+            return nil
+        }
+        
+        return executeAppleScript(script)
+    }
+    
+    /// AppleScript 실행 메서드
+    private func executeAppleScript(_ script: String) -> String? {
+        guard let appleScript = NSAppleScript(source: script) else { return nil }
+        
+        var error: NSDictionary?
+        let result = appleScript.executeAndReturnError(&error)
+        
+        if let error = error {
+            let errorCode = error["NSAppleScriptErrorNumber"] as? Int
+            if errorCode == -1743 {
+                print("⚠️ AppleScript 권한이 필요합니다. 시스템 설정 > 개인정보 보호 및 보안 > 자동화에서 Pawcus가 브라우저를 제어할 수 있도록 허용해주세요.")
+                DispatchQueue.main.async {
+                    self.showAutomationPermissionAlert()
+                }
+            } else {
+                print("❌ AppleScript Error: \(error)")
+            }
+            return nil
+        }
+        
+        return result.stringValue
+    }
+    
+    /// 자동화 권한 알림을 표시하는 메서드
+    private func showAutomationPermissionAlert() {
+        guard let app = NSApplication.shared.delegate as? NSObject else { return }
+        
+        let alert = NSAlert()
+        alert.messageText = "브라우저 자동화 권한 필요"
+        alert.informativeText = "웹 브라우저에서 현재 URL을 추적하려면 자동화 권한이 필요합니다.\n\n시스템 설정 > 개인정보 보호 및 보안 > 자동화에서 Pawcus가 Safari, Chrome 등을 제어할 수 있도록 허용해주세요."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "시스템 설정 열기")
+        alert.addButton(withTitle: "나중에")
+        
+        let response = alert.runModal()
+        if response == .alertFirstButtonReturn {
+            openSystemPreferences()
+        }
+    }
+    
+    /// 시스템 설정 열기 메서드
+    private func openSystemPreferences() {
+        let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation")!
+        NSWorkspace.shared.open(url)
     }
 }

--- a/Pawcus/Pawcus/Pawcus.entitlements
+++ b/Pawcus/Pawcus/Pawcus.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## 🔍 What is this PR?

웹 브라우저(Safari, Chrome, Arc 등)에서 현재 보고 있는 URL을 추적하여 앱 사용 통계에 포함시키는 기능을 추가했습니다.  
기존에는 브라우저의 window title만 가져왔다면, 이제는 실제 URL을 추적하여 더 정확한 웹 사용 패턴을 분석할 수 있습니다.

---

## ✏️ Changes

### 🔧 Core Changes
- `ActivityLogger.swift`: 웹 브라우저 감지 및 URL 추출 로직 추가
  - `isWebBrowser()` : Safari, Chrome, Arc, Firefox, Edge, Opera 감지
  - `getBrowserURL()` : AppleScript를 통한 각 브라우저별 현재 탭 URL 추출
  - `executeAppleScript()` : AppleScript 실행 및 에러 처리
  - `showAutomationPermissionAlert()` : 권한 요청 시 사용자 친화적 알림
  - `openSystemPreferences()` : 시스템 설정 자동화 권한 화면으로 바로 이동

### 🔐 Permission & Configuration
- `Pawcus.entitlements`: `com.apple.security.automation.apple-events` 권한 추가
- `Pawcus-Info.plist`: `NSAppleEventsUsageDescription` 권한 요청 이유 명시

### 📊 Data Enhancement
- 웹 브라우저 사용 시 window title 대신 실제 URL을 로그에 기록
- 사용자의 웹 브라우징 패턴을 더 정확하게 추적 가능

---

## 🧠 고려한 점 / 고민

### 🔒 개인정보 보호
- 사용자의 브라우징 데이터를 수집하는 민감한 기능이므로 명확한 권한 요청 절차 구현
- Info.plist에 상세한 사용 목적 설명 추가

### 🛡️ 권한 처리
- AppleScript 권한이 없을 때 사용자 친화적인 알림 표시
- "시스템 설정 열기" 버튼으로 원클릭 권한 설정 가능하도록 UX 개선

### 🌐 브라우저 호환성
- 주요 브라우저(Safari, Chrome, Arc, Firefox, Edge, Opera)에 대한 포괄적 지원
- 브라우저별로 다른 AppleScript 구문 처리

### ⚡ 성능 최적화
- AppleScript 실행 실패 시 기존 title 방식으로 폴백
- 에러 처리를 통한 앱 안정성 확보

### 🔄 기존 기능 유지
- 웹 브라우저가 아닌 앱들은 기존 window title 추적 방식 그대로 유지
- 하위 호환성 보장

---

## 📎 Related Issues / Links

- 웹 브라우저 URL 추적 요청 사항
- [Apple 공식 문서 - AppleScript 자동화 권한](https://developer.apple.com/documentation/security/authorization_services)